### PR TITLE
New hardware

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -46,7 +46,7 @@ framework = arduino
 monitor_speed = 115200
 board_build.partitions = min_spiffs.csv
 upload_speed = 460800
-build_flags = -D HUZZAH32
+build_flags = -D HUZZAH32 -D TYPE_ET6621S
 lib_deps = 
 	adafruit/Adafruit SSD1306@^2.5.7
 	bblanchon/ArduinoJson@^6.21.3
@@ -65,7 +65,8 @@ board = esp32-s3-devkitc-1
 framework = arduino
 monitor_speed = 115200
 board_build.partitions = min_spiffs.csv
-build_flags = -D DEXCOM_PCB
+;build_flags = -D DEXCOM_PCB -D TYPE_ET6621S
+build_flags = -D DEXCOM_PCB -D TYPE_TM1621D
 lib_deps = 
 	adafruit/Adafruit SSD1306@^2.5.7
 	bblanchon/ArduinoJson@^6.21.3

--- a/src/hwdef.h
+++ b/src/hwdef.h
@@ -48,6 +48,8 @@
 
 #ifdef HUZZAH32
 
+  #define USE_PROJECTOR
+
   #define PIN_BUILTIN_LED 13
   #define BUZZZER_PIN 18
   #define TRIGGER_AP_PIN 4
@@ -62,6 +64,18 @@
   #define SNOOZE_PIN_PLUS 19
   #define SNOOZE_PIN_MINUS 23
 
+  #ifdef TYPE_TM1621D
+    #define PIN_PROJECTOR_CS     15
+    #define PIN_PROJECTOR_CLK    32
+    #define PIN_PROJECTOR_DATA   14
+  #endif
+
+  #ifdef TYPE_ET6621S
+    #define PIN_PROJECTOR_CS     14
+    #define PIN_PROJECTOR_CLK    32
+    #define PIN_PROJECTOR_DATA   15
+  #endif
+
   // i2c protocol support
   #define ESP32_SCL 22
   #define ESP32_SDA 21
@@ -74,19 +88,25 @@
 
 #ifdef DEXCOM_PCB
 
-  #define PIN_BUILTIN_LED 13
-  #define BUZZZER_PIN 26
-  #define TRIGGER_AP_PIN 0//44  44 is a pin that will never trigger...0 is the boot switch
+  #define USE_PROJECTOR
+
+  #define PIN_BUILTIN_LED      13
+  #define BUZZZER_PIN          26
+  #define TRIGGER_AP_PIN       0 //44  44 is a pin that will never trigger...0 is the boot switch
 
   // Populated buttons
-  #define SELECT_PIN 33
-  #define BACK_PIN 12
-  #define RIGHT_PIN 42
-  #define LEFT_PIN 14
-  #define UP_PIN 19
-  #define DOWN_PIN 41
-  #define SNOOZE_PIN_PLUS 1
-  #define SNOOZE_PIN_MINUS 2
+  #define SELECT_PIN           33
+  #define BACK_PIN             12
+  #define RIGHT_PIN            42
+  #define LEFT_PIN             14
+  #define UP_PIN               19
+  #define DOWN_PIN             41
+  #define SNOOZE_PIN_PLUS      1
+  #define SNOOZE_PIN_MINUS     2
+
+  #define PIN_PROJECTOR_CS     15
+  #define PIN_PROJECTOR_CLK    6
+  #define PIN_PROJECTOR_DATA   7
 
   // i2c protocol support
   #define ESP32_SCL 3
@@ -95,6 +115,10 @@
   // This board removes the RGB LED
   #define NO_RGBLED
 
+  // ...and adds a 2.42" OLED and a TC74 temp sensor
+  #define OLED_SSD1306_I2C_ADDRESS 0x3D
+  #define TC74_I2C_ADDRESS 0x48
+  
 #endif
 
 // If we have an RGB LED, be sure to indicate the pins used
@@ -102,4 +126,20 @@
   #define R_PIN 17
   #define G_PIN 16
   #define B_PIN 5
+#endif
+
+#ifdef USE_PROJECTOR
+  //
+  // Projector related details
+  //
+
+  //
+  // RTOS task to update the Projector. Located
+  // in projector.cpp and called from main.cpp.
+  //
+  void projectorUpdateTask();
+
+  // Correction used for onboard temp sensor (to indicate ambient room temp)
+  #define TEMP_CORRECTION 0
+
 #endif

--- a/src/hwdef.h
+++ b/src/hwdef.h
@@ -137,7 +137,7 @@
   // RTOS task to update the Projector. Located
   // in projector.cpp and called from main.cpp.
   //
-  void projectorUpdateTask();
+  void projectorUpdateTask(void *);
 
   // Correction used for onboard temp sensor (to indicate ambient room temp)
   #define TEMP_CORRECTION 0

--- a/src/hwdef.h
+++ b/src/hwdef.h
@@ -108,6 +108,8 @@
   #define PIN_PROJECTOR_CLK    6
   #define PIN_PROJECTOR_DATA   7
 
+  #define PIN_PROJECTOR_PWM    11
+
   // i2c protocol support
   #define ESP32_SCL 3
   #define ESP32_SDA 4
@@ -140,6 +142,6 @@
   void projectorUpdateTask(void *);
 
   // Correction used for onboard temp sensor (to indicate ambient room temp)
-  #define TEMP_CORRECTION 0
+  #define TEMP_CORRECTION -8.5
 
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1036,7 +1036,7 @@ void displayMenu(unsigned int selectedItem, bool sub_menu = false, unsigned int 
         alarmsV.alarms[selectedItem].playsound ? "Yes" : "No",
         melodyNames[alarmsV.alarms[selectedItem].soundName]
 #if !defined NO_RGBLED
-        , alarmsV.alarms[selectedItem].Blink ? "Yes" : "No",
+        , alarmsV.alarms[selectedItem].Blink ? "Yes" : "No"
         , colorNames[alarmsV.alarms[selectedItem].colorArrayPos]
 #endif
         };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1546,6 +1546,7 @@ void setup()
 {
   Serial.begin(115200);
 
+  Serial.printf ("Starting I2C (SDA %d, SCL %d)\n", ESP32_SDA, ESP32_SCL);
   Wire.begin(ESP32_SDA, ESP32_SCL);
 
   // rgb
@@ -1580,6 +1581,7 @@ void setup()
   attachInterrupt(DOWN_PIN, DownPinHandler, FALLING);
 
   // Initialize OLED display
+  // if (!display.begin(SSD1306_SWITCHCAPVCC, 0x3C))
   if (!display.begin(SSD1306_EXTERNALVCC, 0x3C))
   {
     Serial.println(F("SSD1306 allocation failed"));
@@ -1588,7 +1590,6 @@ void setup()
   }
   display.clearDisplay();
   // Set font
-  display.dim(true);
 
   // display.drawBitmap(0, 0, Dexcom_follow_screen, 128, 64, WHITE);
   display.drawBitmap(0, 0, epd_bitmap_logo, 128, 64, WHITE);


### PR DESCRIPTION
This is the 2nd (and final) commit to support the projector hardware and fix some issues with USA based time interpretations.

Please pay special attention to the function `glucoseUpdateTask()` in `main.cpp` (near line 536) as I have removed a number of logic tests to reschedule the next call to Dexcom. It was causing a second request to get schedule almost immediately after an already successful call.

Compiles with default settings (as you would use). Not sure if it works since I do not have your hardware.

All changes:
* add support for determining timezone automatically from GeoIP information ... also recheck every morning at 2:00AM for areas that observe daylight savings time
* add support to add OpenWeatherMap credentials & location via WifiManager (to fetch local outside temperature)
* If `NO_RGB` is defined, change the config menu options. Remove the RGB LED options.
* fix up use of printf() to improve code readability and improve console logging
* remove timezone offset from Dexcom reply when appropriate (for the USA based servers)
* new #define introduced: `USE_PROJECTOR`. If set, this indicates you have the projector board and driver
